### PR TITLE
Fix buttons not working if ActionButtonUseKeyDown is 0

### DIFF
--- a/ElvUI_RaidMarkers.lua
+++ b/ElvUI_RaidMarkers.lua
@@ -186,7 +186,7 @@ function RM:ButtonFactory()
 			button:SetScript("OnLeave", function() GameTooltip:Hide() end)
 		end
 
-		button:RegisterForClicks("AnyDown")
+		button:RegisterForClicks("AnyDown", "AnyUp")
 		self.frame.buttons[i] = button
 	end
 end


### PR DESCRIPTION
Dragonflight prepatch introduced CVar ActionButtonUseKeyDown; which means you have to register UP/DOWN, depending on the CVar value (or just register both up and down, as done in the PR)